### PR TITLE
make the snapshotter a self-configuring singleton

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,11 +1,11 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "branch": "develop"
+    "branch": "fix/remaining-camel-case-api-changes"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",
-    "branch": "develop"
+    "branch": "chore/update-to-camel-case-api"
   },
   "space:testing": {
     "git":"https://github.com/meteor-space/testing.git",

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,7 +1,7 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "branch": "develop"
+    "branch": "529afaea937a2f16abd5a968c24d26a4ea879369"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,7 +1,7 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "branch": "529afaea937a2f16abd5a968c24d26a4ea879369"
+    "branch": "develop"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",
@@ -9,6 +9,6 @@
   },
   "space:testing": {
     "git":"https://github.com/meteor-space/testing.git",
-    "branch": "8ca3596fa4fda111228fdba304580e70391306d4"
+    "branch": "develop"
   }
 }

--- a/package.js
+++ b/package.js
@@ -15,6 +15,7 @@ Package.onUse(function(api) {
     'underscore',
     'check',
     'mongo',
+    'ecmascript',
     'mikowals:batch-insert@1.1.9',
     'space:base@3.1.0',
     'space:messaging@2.1.0'
@@ -27,6 +28,7 @@ Package.onUse(function(api) {
     'source/server/module.coffee',
     // INFRASTRUCTURE
     'source/server/infrastructure/repository.coffee',
+    'source/server/infrastructure/snapshot.js',
     'source/server/infrastructure/snapshotter.coffee',
     'source/server/infrastructure/commit_store.coffee',
     'source/server/infrastructure/commit_publisher.coffee',
@@ -35,7 +37,7 @@ Package.onUse(function(api) {
     'source/server/infrastructure/router.coffee',
     // DOMAIN
     'source/server/domain/aggregate.coffee',
-    'source/server/domain/process.coffee',
+    'source/server/domain/process.coffee'
   ], 'server');
 
 });

--- a/source/server/infrastructure/commit_publisher.coffee
+++ b/source/server/infrastructure/commit_publisher.coffee
@@ -3,9 +3,9 @@ class Space.eventSourcing.CommitPublisher extends Space.Object
 
   @type 'Space.eventSourcing.CommitPublisher'
 
-  Dependencies:
+  dependencies:
     commits: 'Space.eventSourcing.Commits'
-    configuration: 'Configuration'
+    configuration: 'configuration'
     eventBus: 'Space.messaging.EventBus'
     commandBus: 'Space.messaging.CommandBus'
     ejson: 'EJSON'

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -3,10 +3,10 @@ class Space.eventSourcing.CommitStore extends Space.Object
 
   @type 'Space.eventSourcing.CommitStore'
 
-  Dependencies:
+  dependencies:
     commits: 'Space.eventSourcing.Commits'
     commitPublisher: 'Space.eventSourcing.CommitPublisher'
-    configuration: 'Configuration'
+    configuration: 'configuration'
     log: 'Space.eventSourcing.Log'
 
   add: (changes, sourceId, expectedVersion) ->

--- a/source/server/infrastructure/projection.coffee
+++ b/source/server/infrastructure/projection.coffee
@@ -9,8 +9,8 @@ class Space.eventSourcing.Projection extends Space.Object
   constructor: ->
     super
     @_queuedEvents = []
-    @Dependencies = {}
-    _.extend @Dependencies, @constructor::Dependencies, @Collections
+    @dependencies = {}
+    _.extend @dependencies, @constructor::dependencies, @Collections
 
   on: (event, isReplay=false) ->
     return unless @canHandleEvent(event)

--- a/source/server/infrastructure/projector.coffee
+++ b/source/server/infrastructure/projector.coffee
@@ -2,7 +2,7 @@ class Space.eventSourcing.Projector extends Space.Object
 
   @type 'Space.eventSourcing.Projector'
 
-  Dependencies: {
+  dependencies: {
     commitStore: 'Space.eventSourcing.CommitStore'
     injector: 'Injector'
     mongo: 'Mongo'

--- a/source/server/infrastructure/repository.coffee
+++ b/source/server/infrastructure/repository.coffee
@@ -1,7 +1,7 @@
 
 class Space.eventSourcing.Repository extends Space.Object
 
-  Dependencies:
+  dependencies:
     commitStore: 'Space.eventSourcing.CommitStore'
 
   # Optional snapshotter that can be configured via `useSnapshotter`

--- a/source/server/infrastructure/router.coffee
+++ b/source/server/infrastructure/router.coffee
@@ -15,7 +15,7 @@ class Space.eventSourcing.Router extends Space.messaging.Controller
                  handle #{command.typeName()}"
   }
 
-  Dependencies: {
+  dependencies: {
     repository: 'Space.eventSourcing.Repository'
     commitStore: 'Space.eventSourcing.CommitStore'
     log: 'Space.eventSourcing.Log'

--- a/source/server/infrastructure/snapshot.js
+++ b/source/server/infrastructure/snapshot.js
@@ -1,0 +1,9 @@
+Space.messaging.Serializable.extend(Space.eventSourcing, 'Snapshot', {
+  fields() {
+    return {
+      id: Match.OneOf(String, Guid),
+      version: Match.Integer,
+      state: Match.OneOf(null, String)
+    };
+  }
+});

--- a/source/server/infrastructure/snapshotter.coffee
+++ b/source/server/infrastructure/snapshotter.coffee
@@ -13,9 +13,6 @@ class Space.eventSourcing.Snapshotter extends Space.Object
   versionFrequency: 0
 
   onDependenciesReady: ->
-    @_setupSnapshotting() if @configuration.eventSourcing.snapshotting.enabled
-
-  _setupSnapshotting: ->
     if Snapshotter.snapshotsCollection?
       SnapshotsCollection = Snapshotter.snapshotsCollection
     else

--- a/source/server/infrastructure/snapshotter.coffee
+++ b/source/server/infrastructure/snapshotter.coffee
@@ -10,7 +10,7 @@ class Space.eventSourcing.Snapshotter extends Space.Object
   }
 
   collection: null
-  _versionFrequency: 0
+  versionFrequency: 0
 
   onDependenciesReady: ->
     @_setupSnapshotting() if @configuration.eventSourcing.snapshotting.enabled
@@ -27,7 +27,7 @@ class Space.eventSourcing.Snapshotter extends Space.Object
       Snapshotter.snapshotsCollection = SnapshotsCollection
 
     @collection = SnapshotsCollection
-    @_versionFrequency = @configuration.eventSourcing.snapshotting.frequency
+    @versionFrequency = @configuration.eventSourcing.snapshotting.frequency
     @injector.map('Space.eventSourcing.Snapshots').to SnapshotsCollection
     @injector.get('Space.eventSourcing.Repository').useSnapshotter this
 
@@ -37,7 +37,7 @@ class Space.eventSourcing.Snapshotter extends Space.Object
     data = @collection.findOne _id: id
     data?.snapshot = @ejson.parse(data.snapshot)
     snapshot = aggregate.getSnapshot()
-    if data? and data.snapshot.version <= currentVersion - @_versionFrequency
+    if data? and data.snapshot.version <= currentVersion - @versionFrequency
       # Update existing snapshot of this aggregate
       @collection.update {_id: id}, $set: snapshot: @ejson.stringify(snapshot)
     else if !data?

--- a/source/server/infrastructure/snapshotter.coffee
+++ b/source/server/infrastructure/snapshotter.coffee
@@ -2,8 +2,8 @@ class Space.eventSourcing.Snapshotter extends Space.Object
 
   @snapshotsCollection: null
 
-  Dependencies: {
-    configuration: 'Configuration'
+  dependencies: {
+    configuration: 'configuration'
     ejson: 'EJSON'
     injector: 'Injector'
     mongo: 'Mongo'

--- a/source/server/module.coffee
+++ b/source/server/module.coffee
@@ -58,6 +58,9 @@ class Space.eventSourcing extends Space.Module
     @injector.map('Space.eventSourcing.Log').to =>
       console.log.apply(null, arguments) if @Configuration.eventSourcing.log.enabled
 
+  _setupMongoConfiguration: ->
+    @Configuration.eventSourcing.mongo.connection = @_mongoConnection()
+      
   _setupCommitsCollection: ->
     if Space.eventSourcing.commitsCollection?
       CommitsCollection = Space.eventSourcing.commitsCollection
@@ -78,9 +81,6 @@ class Space.eventSourcing extends Space.Module
       return _driver: new @mongoInternals.RemoteCollectionDriver(mongoUrl, driverOptions)
     else
       return {}
-
-  _setupMongoConfiguration: ->
-    @Configuration.eventSourcing.mongo.connection = @_mongoConnection()
 
   _externalMongo: ->
     true if Space.getenv('SPACE_ES_COMMITS_MONGO_URL', '').length > 0

--- a/source/server/module.coffee
+++ b/source/server/module.coffee
@@ -39,6 +39,8 @@ class Space.eventSourcing extends Space.Module
     @_setupLogging()
     @_setupMongoConfiguration()
     @_setupCommitsCollection()
+
+  afterInitialize: ->
     @commitPublisher = @injector.get('Space.eventSourcing.CommitPublisher')
 
   onStart: ->

--- a/source/server/module.coffee
+++ b/source/server/module.coffee
@@ -31,16 +31,17 @@ class Space.eventSourcing extends Space.Module
     'Space.eventSourcing.CommitPublisher'
     'Space.eventSourcing.Repository'
     'Space.eventSourcing.Projector'
-    'Space.eventSourcing.Snapshotter'
   ]
 
   onInitialize: ->
+    @injector.map('Space.eventSourcing.Snapshotter').asSingleton() if @_isSnapshotting()
     # Right now logging is not optional, and hard coded to output to console, but the Config API included a switch and writeStream
     @_setupLogging()
     @_setupMongoConfiguration()
     @_setupCommitsCollection()
 
   afterInitialize: ->
+    @injector.create('Space.eventSourcing.Snapshotter') if @_isSnapshotting()
     @commitPublisher = @injector.get('Space.eventSourcing.CommitPublisher')
 
   onStart: ->
@@ -86,3 +87,5 @@ class Space.eventSourcing extends Space.Module
 
   _externalMongoNeedsOplog: ->
     true if Space.getenv('SPACE_ES_COMMITS_MONGO_OPLOG_URL', '').length > 0
+
+  _isSnapshotting: -> @Configuration.eventSourcing.snapshotting.enabled

--- a/source/server/module.coffee
+++ b/source/server/module.coffee
@@ -5,7 +5,7 @@ class Space.eventSourcing extends Space.Module
 
   @commitsCollection: null
 
-  Configuration: Space.getenv.multi({
+  configuration: Space.getenv.multi({
     eventSourcing: {
       log: {
         enabled: ['SPACE_ES_LOG_ENABLED', false, 'bool']
@@ -20,14 +20,14 @@ class Space.eventSourcing extends Space.Module
     }
   })
 
-  RequiredModules: ['Space.messaging']
+  requiredModules: ['Space.messaging']
 
-  Dependencies: {
+  dependencies: {
     mongo: 'Mongo'
     mongoInternals: 'MongoInternals'
   }
 
-  Singletons: [
+  singletons: [
     'Space.eventSourcing.CommitPublisher'
     'Space.eventSourcing.Repository'
     'Space.eventSourcing.Projector'
@@ -56,11 +56,11 @@ class Space.eventSourcing extends Space.Module
 
   _setupLogging: ->
     @injector.map('Space.eventSourcing.Log').to =>
-      console.log.apply(null, arguments) if @Configuration.eventSourcing.log.enabled
+      console.log.apply(null, arguments) if @configuration.eventSourcing.log.enabled
 
   _setupMongoConfiguration: ->
-    @Configuration.eventSourcing.mongo.connection = @_mongoConnection()
-      
+    @configuration.eventSourcing.mongo.connection = @_mongoConnection()
+
   _setupCommitsCollection: ->
     if Space.eventSourcing.commitsCollection?
       CommitsCollection = Space.eventSourcing.commitsCollection
@@ -88,4 +88,4 @@ class Space.eventSourcing extends Space.Module
   _externalMongoNeedsOplog: ->
     true if Space.getenv('SPACE_ES_COMMITS_MONGO_OPLOG_URL', '').length > 0
 
-  _isSnapshotting: -> @Configuration.eventSourcing.snapshotting.enabled
+  _isSnapshotting: -> @configuration.eventSourcing.snapshotting.enabled

--- a/tests/infrastructure/replaying-projections.tests.coffee
+++ b/tests/infrastructure/replaying-projections.tests.coffee
@@ -48,7 +48,6 @@ describe 'Space.eventSourcing - replaying projections', ->
     }
 
     afterInitialize: ->
-      @reset()
       @injector.map('FirstCollection').to FirstCollection
       @injector.map('SecondCollection').to SecondCollection
       @injector.map('FirstProjection').toSingleton FirstProjection
@@ -65,7 +64,7 @@ describe 'Space.eventSourcing - replaying projections', ->
       SecondCollection.remove {}
       @event = new TestEvent sourceId: 'test123', value: 'test'
       @app = new TestApp()
-      @app.configure { appId: 'TestApp' }
+      @app.reset()
       @app.start()
 
     afterEach ->

--- a/tests/infrastructure/replaying-projections.tests.coffee
+++ b/tests/infrastructure/replaying-projections.tests.coffee
@@ -42,8 +42,8 @@ describe 'Space.eventSourcing - replaying projections', ->
 
   class TestApp extends Space.Application
 
-    RequiredModules: ['Space.eventSourcing']
-    Configuration: {
+    requiredModules: ['Space.eventSourcing']
+    configuration: {
       appId: 'TestApp'
     }
 
@@ -86,8 +86,8 @@ describe 'Space.eventSourcing - replaying projections', ->
         }
         insertedAt: new Date()
         eventTypes: [TestEvent]
-        sentBy: @app.Configuration.appId
-        receivedBy: [@app.Configuration.appId]
+        sentBy: @app.configuration.appId
+        receivedBy: [@app.configuration.appId]
       }
 
       projector = @app.injector.get 'Space.eventSourcing.Projector'

--- a/tests/infrastructure/snapshotter.unit.coffee
+++ b/tests/infrastructure/snapshotter.unit.coffee
@@ -5,7 +5,8 @@ describe 'Space.eventSourcing.Snapshotter', ->
 
   class MySnapshotAggregate extends Space.eventSourcing.Aggregate
     @toString: -> 'MySnapshotAggregate'
-    @FIELDS: test: null
+    @Fields: test: String
+    @registerSnapshotType 'MySnapshotAggregate'
 
   class MySnapshotApp extends Space.Application
     RequiredModules: ['Space.eventSourcing']

--- a/tests/infrastructure/snapshotter.unit.coffee
+++ b/tests/infrastructure/snapshotter.unit.coffee
@@ -9,8 +9,8 @@ describe 'Space.eventSourcing.Snapshotter', ->
     @registerSnapshotType 'MySnapshotAggregate'
 
   class MySnapshotApp extends Space.Application
-    RequiredModules: ['Space.eventSourcing']
-    Configuration: {
+    requiredModules: ['Space.eventSourcing']
+    configuration: {
       eventSourcing: {
         snapshotting: {
           enabled: true,
@@ -38,7 +38,7 @@ describe 'Space.eventSourcing.Snapshotter', ->
   describe 'making snapshots', ->
 
     it 'saves the current state of the aggregate', ->
-      @aggregate._version = @myApp.Configuration.eventSourcing.snapshotting.frequency
+      @aggregate._version = @myApp.configuration.eventSourcing.snapshotting.frequency
       @snapshotter.makeSnapshotOf @aggregate
       expect(@collection.findOne()).toMatch {
         _id: @aggregateId

--- a/tests/test_application.coffee
+++ b/tests/test_application.coffee
@@ -8,13 +8,13 @@ class @CustomerApp extends Space.Application
 
   @publish this, 'CustomerApp'
 
-  RequiredModules: ['Space.eventSourcing']
+  requiredModules: ['Space.eventSourcing']
 
-  Dependencies: {
+  dependencies: {
     mongo: 'Mongo'
   }
 
-  Configuration: {
+  configuration: {
     appId: 'CustomerApp'
     eventSourcing: {
       snapshotting: {
@@ -142,7 +142,7 @@ CustomerApp.CustomerRegistration.registerSnapshotType 'CustomerApp.CustomerRegis
 
 class CustomerApp.CustomerRegistrationRouter extends Space.eventSourcing.Router
 
-  Dependencies: {
+  dependencies: {
     registrations: 'CustomerApp.CustomerRegistrations'
   }
 
@@ -199,7 +199,7 @@ class CustomerApp.EmailRouter extends Space.Object
 
 class CustomerApp.CustomerRegistrationProjection extends Space.eventSourcing.Projection
 
-  Dependencies: {
+  dependencies: {
     registrations: 'CustomerApp.CustomerRegistrations'
   }
 

--- a/tests/test_application.coffee
+++ b/tests/test_application.coffee
@@ -79,6 +79,8 @@ class CustomerApp.Customer extends Space.eventSourcing.Aggregate
     'CustomerApp.CustomerCreated': (event) -> @name = event.customerName
   }
 
+CustomerApp.Customer.registerSnapshotType 'CustomerApp.CustomerSnapshot'
+
 # -------------- PROCESSES ---------------
 
 class CustomerApp.CustomerRegistration extends Space.eventSourcing.Process
@@ -133,6 +135,8 @@ class CustomerApp.CustomerRegistration extends Space.eventSourcing.Process
   _onRegistrationInitiated: (event) ->
     { @customerId, @customerName } = event
     @_state = @STATES.creatingCustomer
+
+CustomerApp.CustomerRegistration.registerSnapshotType 'CustomerApp.CustomerRegistrationSnapshot'
 
 # -------------- ROUTERS --------------- #
 

--- a/tests/test_application.coffee
+++ b/tests/test_application.coffee
@@ -63,8 +63,8 @@ Space.messaging.define Space.messaging.Event, 'CustomerApp', {
 
 class CustomerApp.Customer extends Space.eventSourcing.Aggregate
 
-  FIELDS: {
-    name: null
+  Fields: {
+    name: String
   }
 
   commandMap: -> {
@@ -83,15 +83,15 @@ class CustomerApp.Customer extends Space.eventSourcing.Aggregate
 
 class CustomerApp.CustomerRegistration extends Space.eventSourcing.Process
 
-  FIELDS: {
-    customerId: null
-    customerName: null
+  Fields: {
+    customerId: String
+    customerName: String
   }
 
   STATES: {
-    creatingCustomer: 0
-    sendingWelcomeEmail: 1
-    completed: 2
+    creatingCustomer: 'creatingCustomer'
+    sendingWelcomeEmail: 'sendingWelcomeEmail'
+    completed: 'completed'
   }
 
   commandMap: -> {


### PR DESCRIPTION
This PR improves the snapshotting feature by making the following changes:

* `Space.eventSourcing.Snapshotter` is now a self-configuring singleton
* snapshots are EJSON serialized so that aggregates can be correctly de-serialized from complex snapshots. This is necessary, so that we can have entities / value objects in our aggregates :wink: 