### PR TITLE
Feature/improve process router

### DIFF
--- a/source/server/infrastructure/aggregate-router.coffee
+++ b/source/server/infrastructure/aggregate-router.coffee
@@ -56,5 +56,4 @@ class Space.eventSourcing.AggregateRouter extends Space.messaging.Controller
     aggregate.handle command
     @repository.save aggregate
 
-  _logMsg: (message) ->
-    "#{@configuration.appId}: #{this}: #{message}"
+  _logMsg: (message) -> "#{@configuration.appId}: #{this}: #{message}"

--- a/source/server/module.coffee
+++ b/source/server/module.coffee
@@ -29,6 +29,7 @@ class Space.eventSourcing extends Space.Module
 
   singletons: [
     'Space.eventSourcing.CommitPublisher'
+    'Space.eventSourcing.CommitStore'
     'Space.eventSourcing.Repository'
     'Space.eventSourcing.Projector'
   ]


### PR DESCRIPTION
Process Routers can now route commands **and** events to processes. That is needed e.g. by `Space.accounts.Signup` which is initialized with a `InitiateSignup` command but also needs to handle `RetrySignup` :wink:

Let's see how this evolves, but for now this is the best solution i came up with.