### PR TITLE
Fix/improve event persistence

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -1,11 +1,11 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "branch": "feature/serializing-structs"
+    "version": "c6b32c392ef3e2e79173cc8bb9f82229032af893"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",
-    "branch": "feature/struct-serialization"
+    "version": "6aae8398809cfa68a90acf4c631efbdca50139b4"
   },
   "space:domain": {
     "git":"https://github.com/meteor-space/domain.git",

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,11 +1,11 @@
 {
   "space:base": {
     "git":"https://github.com/meteor-space/base.git",
-    "version": "8b51727cced10d6da5d85c92d0052a768e21cf0e"
+    "branch": "feature/serializing-structs"
   },
   "space:messaging": {
     "git":"https://github.com/meteor-space/messaging.git",
-    "version": "2ec04c0d3004df3fa3f95ebaecff51917676f9ce"
+    "branch": "feature/struct-serialization"
   },
   "space:domain": {
     "git":"https://github.com/meteor-space/domain.git",

--- a/source/server/infrastructure/commit_publisher.coffee
+++ b/source/server/infrastructure/commit_publisher.coffee
@@ -66,12 +66,12 @@ class Space.eventSourcing.CommitPublisher extends Space.Object
     # Only parse events that can be handled by this app
     for event in commit.changes.events
       if @_supportsEjsonType event.type
-        EventType = Space.Struct.resolve(event.type)
+        EventType = Space.messaging.Serializable.resolve(event.type)
         events.push EventType.fromData(event.data)
     # Only parse commands that can be handled by this app
     for command in commit.changes.commands
       if @_supportsEjsonType(command.type) and @commandBus.hasHandlerFor(command.type)
-        CommandType = Space.Struct.resolve(command.type)
+        CommandType = Space.messaging.Serializable.resolve(command.type)
         commands.push CommandType.fromData(command.data)
 
     commit.changes.events = events

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -86,7 +86,7 @@ class Space.eventSourcing.CommitStore extends Space.Object
     commits.forEach (commit) =>
       for event in commit.changes.events
         try
-          event = Space.Struct.resolve(event.type).fromData(event.data)
+          event = Space.messaging.Serializable.resolve(event.type).fromData(event.data)
         catch error
           throw new Error "while parsing commit\nevent:#{event}\nerror:#{error}"
         events.push event

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -36,13 +36,16 @@ class Space.eventSourcing.CommitStore extends Space.Object
       @_setEventVersion(event, newVersion) for event in changes.events
       # serialize events and commands
       serializedChanges = events: [], commands: []
-      serializedChanges.events.push(EJSON.stringify(event)) for event in changes.events
-      serializedChanges.commands.push(EJSON.stringify(command)) for command in changes.commands
+      for event in changes.events
+        serializedChanges.events.push type: event.typeName(), data: event.toData()
+
+      for command in changes.commands
+        serializedChanges.commands.push type: command.typeName(), data: command.toData()
 
       commit = {
         sourceId: sourceId.toString()
         version: newVersion
-        changes: serializedChanges # insert EJSON serialized changes
+        changes: serializedChanges
         insertedAt: new Date()
         eventTypes: @_getEventTypes(changes.events)
         sentBy: @configuration.appId
@@ -83,7 +86,7 @@ class Space.eventSourcing.CommitStore extends Space.Object
     commits.forEach (commit) =>
       for event in commit.changes.events
         try
-          event = EJSON.parse(event)
+          event = Space.Struct.resolve(event.type).fromData(event.data)
         catch error
           throw new Error "while parsing commit\nevent:#{event}\nerror:#{error}"
         events.push event

--- a/tests/infrastructure/commit_store.unit.coffee
+++ b/tests/infrastructure/commit_store.unit.coffee
@@ -60,8 +60,8 @@ describe "Space.eventSourcing.CommitStore", ->
         sourceId: sourceId
         version: newVersion
         changes:
-          events: [EJSON.stringify(testEvent)]
-          commands: [EJSON.stringify(testCommand)]
+          events: [type: testEvent.typeName(), data: testEvent.toData()]
+          commands: [type: testCommand.typeName(), data: testCommand.toData()]
         insertedAt: sinon.match.date
         sentBy: @appId
         receivers: [{ appId: @appId, receivedAt: new Date() }]

--- a/tests/infrastructure/replaying-projections.tests.coffee
+++ b/tests/infrastructure/replaying-projections.tests.coffee
@@ -81,7 +81,7 @@ describe 'Space.eventSourcing - replaying projections', ->
         sourceId: @event.sourceId
         version: 1
         changes: {
-          events: [EJSON.stringify(@event)]
+          events: [type: @event.typeName(), data: @event.toData()]
           commands: []
         }
         insertedAt: new Date()


### PR DESCRIPTION
This PR changes the way commits are persisted.
It moves away from EJSON in favor of our new `Space.Struct` data serialization apis.
This makes commit data easily to query! :smiley: 