### PR TITLE
Add space:testing-event-sourcing to dependency

### DIFF
--- a/git-packages.json
+++ b/git-packages.json
@@ -13,6 +13,10 @@
   },
   "space:testing": {
     "git":"https://github.com/meteor-space/testing.git",
-    "version": "7382d37f06a553664255f4ec82b4e8bea6fb890d"
+    "version": "3974bd7f7e3cd467a3c29136afcd773c9ba6913a"
+  },
+  "space:testing-event-sourcing": {
+    "git":"https://github.com/meteor-space/testing-event-sourcing.git",
+    "version": "564629e234df55ba27617d1cfe69830725a1d74f"
   }
 }

--- a/package.js
+++ b/package.js
@@ -55,8 +55,9 @@ Package.onTest(function(api) {
     'ecmascript',
     'space:event-sourcing',
     'space:testing@2.0.0',
+    'space:testing-event-sourcing@0.1.0',
     'practicalmeteor:munit@2.1.5'
-  ]);
+  ], 'server');
 
   api.addFiles([
     // HELPERS


### PR DESCRIPTION
This change is to support the extracted event-sourcing testing API from space:testing. In implementations only the specific testing package will be required, but this is the most explicit