### PR TITLE
updates the snapshot setup to latest apis

### DIFF
--- a/source/server/domain/aggregate.coffee
+++ b/source/server/domain/aggregate.coffee
@@ -28,7 +28,7 @@ class Space.eventSourcing.Aggregate extends Space.Object
 
   @registerSnapshotType: (id) ->
     fields = {}
-    fields[field] = type for field, type of @fields
+    fields[field] = type for field, type of this::fields
     @_snapshotType = Space.eventSourcing.Snapshot.extend id, {
       fields: ->
         superFields = Space.eventSourcing.Snapshot::fields()

--- a/source/server/domain/aggregate.coffee
+++ b/source/server/domain/aggregate.coffee
@@ -28,13 +28,12 @@ class Space.eventSourcing.Aggregate extends Space.Object
 
   @registerSnapshotType: (id) ->
     fields = {}
-    fields[field] = type for field, type of this::fields
-    @_snapshotType = Space.eventSourcing.Snapshot.extend {
+    fields[field] = type for field, type of @fields
+    @_snapshotType = Space.eventSourcing.Snapshot.extend id, {
       fields: ->
-        superFields = Space.eventSourcing.Snapshot::fields.call(this)
+        superFields = Space.eventSourcing.Snapshot::fields()
         return _.extend(superFields, fields)
     }
-    @_snapshotType.type id
 
   constructor: (id, data, isSnapshot) ->
     unless id? then throw new Error Aggregate::ERRORS.guidRequired


### PR DESCRIPTION
This fixes the strange `future` bla error which was caused by wrong setup of the snapshotter classes for aggregates. So the struct mixins in the testing packages have not been the issue here.