### PR TITLE
Add Repository tests to document the expected behaviour

### DIFF
--- a/package.js
+++ b/package.js
@@ -67,6 +67,7 @@ Package.onTest(function(api) {
     'tests/domain/aggregate.unit.coffee',
     'tests/domain/process.unit.coffee',
     // INFRASTRUCTURE
+    'tests/infrastructure/repository.unit.coffee',
     'tests/infrastructure/commit_store.unit.coffee',
     'tests/infrastructure/commit_publisher.unit.coffee',
     'tests/infrastructure/snapshotter.unit.coffee',

--- a/tests/infrastructure/repository.unit.coffee
+++ b/tests/infrastructure/repository.unit.coffee
@@ -52,21 +52,21 @@ describe "Space.eventSourcing.Repository", ->
 
     it 'saves changes from the provided aggregate instance as a serialized and versioned commit', ->
 
-      expectedVersion = 0
+      expectedVersion = 1
       @repository.save @myAggregate
       insertedCommits = @commitStore.commits.find().fetch()
 
-      serializedCommit = {
+      expectedCommit = {
         _id: insertedCommits[0]._id
-        sourceId: @aggregateId
+        sourceId: @aggregateId.toString()
         version: expectedVersion
         changes:
           events: [type: @createdEvent.typeName(), data: @createdEvent.toData()]
-          commands: [type: @initiatingCommand.typeName(), data: @initiatingCommand.toData()]
-        insertedAt: sinon.match.date
+          commands: []
+        insertedAt: new Date()
         sentBy: @appId
         receivers: [{ appId: @appId, receivedAt: new Date() }]
         eventTypes: [@createdEvent.toString()]
       }
 
-      expect(insertedCommits).toMatch [serializedCommit]
+      expect(insertedCommits).toMatch [expectedCommit]

--- a/tests/infrastructure/repository.unit.coffee
+++ b/tests/infrastructure/repository.unit.coffee
@@ -8,10 +8,10 @@ Command = Space.domain.Command
 # =========== TEST DATA ========== #
 
 class MyAggregate extends Aggregate
-  @type 'Space.eventSourcing.Repository.TestAggregate'
+  @type 'Space.eventSourcing.Repository.MyAggregate'
 
 class MyProcess extends Process
-  @type 'Space.eventSourcing.Repository.TestProcess'
+  @type 'Space.eventSourcing.Repository.MyProcess'
 
 class MyInitiatingCommand extends Command
   @type 'Space.eventSourcing.Repository.MyInitiatingCommand'
@@ -108,3 +108,21 @@ describe "Space.eventSourcing.Repository", ->
       }
 
       expect(insertedCommits).toMatch [expectedCommit]
+
+  describe '#find', ->
+
+    it 'returns a re-hydrated instance of the expected version by type and id', ->
+      # Version 1
+      myAggregate = new MyAggregate(@aggregateId, @initiatingCommand)
+      myAggregate.record(@myCreatedEvent)
+      @repository.save(myAggregate)
+      myAggregate._events = []
+      # Version 2
+      myAggregate.record(@myCreatedEvent)
+      @repository.save(myAggregate)
+      myAggregate._events = []
+      rehydratedInstance = @repository.find(MyAggregate, @aggregateId)
+      expect(rehydratedInstance).toMatch(myAggregate)
+      expect(rehydratedInstance._version).to.equal(2)
+
+

--- a/tests/infrastructure/repository.unit.coffee
+++ b/tests/infrastructure/repository.unit.coffee
@@ -1,0 +1,72 @@
+Repository = Space.eventSourcing.Repository
+CommitStore = Space.eventSourcing.CommitStore
+Aggregate = Space.eventSourcing.Aggregate
+Event = Space.domain.Event
+Command = Space.domain.Command
+
+# =========== TEST DATA ========== #
+
+class MyAggregate extends Aggregate
+  @type 'Space.eventSourcing.CommitStore.TestEvent'
+
+class InitiatingCommand extends Command
+  @type 'Space.eventSourcing.Repository.InitiatingCommand'
+
+class CreatedEvent extends Event
+  @type 'Space.eventSourcing.Repository.CreatedEvent', ->
+
+# =========== SPECS ============= #
+
+describe "Space.eventSourcing.Repository", ->
+
+  beforeEach ->
+    @clock = sinon.useFakeTimers(Date.now(), 'Date')
+    @appId = 'TestApp'
+    @aggregateId = new Guid()
+    @initiatingCommand = new InitiatingCommand({
+      targetId: @aggregateId
+      timestamp: new Date()
+    })
+    @createdEvent = new CreatedEvent({
+      sourceId: @aggregateId
+      version: 0
+      timestamp: new Date()
+    })
+    @myAggregate = new Aggregate(@aggregateId, @initiatingCommand)
+    @myAggregate.record(@createdEvent)
+    @commitStore = new CommitStore {
+      commits: new Mongo.Collection(null)
+      commitPublisher: { publishCommit: -> }
+      configuration: { appId: @appId }
+      log: Space.log
+    }
+    @repository = new Repository {
+      commitStore: @commitStore
+    }
+
+
+  afterEach ->
+    @clock.restore()
+
+  describe '#save', ->
+
+    it 'saves changes from the provided aggregate instance as a serialized and versioned commit', ->
+
+      expectedVersion = 0
+      @repository.save @myAggregate
+      insertedCommits = @commitStore.commits.find().fetch()
+
+      serializedCommit = {
+        _id: insertedCommits[0]._id
+        sourceId: @aggregateId
+        version: expectedVersion
+        changes:
+          events: [type: @createdEvent.typeName(), data: @createdEvent.toData()]
+          commands: [type: @initiatingCommand.typeName(), data: @initiatingCommand.toData()]
+        insertedAt: sinon.match.date
+        sentBy: @appId
+        receivers: [{ appId: @appId, receivedAt: new Date() }]
+        eventTypes: [@createdEvent.toString()]
+      }
+
+      expect(insertedCommits).toMatch [serializedCommit]

--- a/tests/infrastructure/repository.unit.coffee
+++ b/tests/infrastructure/repository.unit.coffee
@@ -63,7 +63,7 @@ describe "Space.eventSourcing.Repository", ->
         changes:
           events: [type: @createdEvent.typeName(), data: @createdEvent.toData()]
           commands: []
-        insertedAt: new Date()
+        insertedAt: sinon.match.date
         sentBy: @appId
         receivers: [{ appId: @appId, receivedAt: new Date() }]
         eventTypes: [@createdEvent.toString()]


### PR DESCRIPTION
Ok so this is quite simple, and it's only ~~slipped through~~ an issue as we had a gap in test coverage on the class. ~~`Space.eventSourcing.Repository#save()` currently calls a non-existent instance method `getCommands()`, which the logic allowed without borking for some reason. This resulting in no error thrown and an empty array being persisted.~~  

- [x] Add tests
- [ ] ~~add `triggeringMessage` field to commit as the metadata @darko-mijic has been expecting to be in `commands`~~