### PR TITLE
Do not throw errors if there is no data to insert after rebuilding projected collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 ## newVersion
 ### Changes to projection rebuilder
-- `Space.eventSourcing.ProjectionRebuilder ` is no longer throwing an error if there is no data to insert into collection after rebuilding is done. Warning message is now logged instead. 
+- `Space.eventSourcing.ProjectionRebuilder ` is no longer throwing an error if there is no data to insert into collection after rebuilding is done. Info message is now logged instead. 
 
 ## 3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+## newVersion
+### Changes to projection rebuilder
+- `Space.eventSourcing.ProjectionRebuilder ` is no longer throwing an error if there is no data to insert into collection after rebuilding is done. Warning message is now logged instead. 
+
 ## 3.0.0
 
 ### New Features

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -4,8 +4,10 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
 
   dependencies: {
     commitStore: 'Space.eventSourcing.CommitStore'
+    configuration: 'configuration'
     injector: 'Injector'
     mongo: 'Mongo'
+    log: 'log'
   }
 
   rebuild: (projections, options) ->
@@ -42,7 +44,7 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
       if inMemoryData.length
         realCollection.batchInsert inMemoryData
       else
-        throw new Error "No data to insert after replaying events for #{collectionId}"
+        @log.warning(@_logMsg("No data to insert after replaying events for #{collectionId}"))
       # Restore original collections
       @injector.override(collectionId).to realCollection
 
@@ -54,3 +56,6 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
     for property, id of projection.collections
       collectionIds.push(id) if projection[property]
     return collectionIds
+
+  _logMsg: (message) ->
+    "#{@configuration.appId}: #{this}: #{message}"

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -44,7 +44,7 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
       if inMemoryData.length
         realCollection.batchInsert inMemoryData
       else
-        @log.warning(@_logMsg("No data to insert after replaying events for #{collectionId}"))
+        @log.info(@_logMsg("No data to insert after replaying events for #{collectionId}"))
       # Restore original collections
       @injector.override(collectionId).to realCollection
 


### PR DESCRIPTION
Empty collection after rebuilding is valid case in my opinion. 
One real world example: Dedicated projected collection where items are removed after they are not needed by view requirements.