### PR TITLE
Aggregate throws an error when snapshot type is not registered

### DIFF
--- a/source/server/domain/aggregate.coffee
+++ b/source/server/domain/aggregate.coffee
@@ -37,7 +37,7 @@ class Space.eventSourcing.Aggregate extends Space.Object
     }
 
   constructor: (id, data, isSnapshot) ->
-#    unless id? then throw new Error Aggregate::ERRORS.guidRequired
+    unless id? then throw new Error Aggregate::ERRORS.guidRequired
     # This aggregate is created from a command -> assign targetId
     @_id = if (id instanceof Command) then id.targetId else id
     @_events = []

--- a/source/server/domain/aggregate.coffee
+++ b/source/server/domain/aggregate.coffee
@@ -59,7 +59,7 @@ class Space.eventSourcing.Aggregate extends Space.Object
   getEvents: -> @_events
 
   getSnapshot: ->
-#    unless @constructor._snapshotType? then throw new Error Aggregate::ERRORS.undefinedSnapshotTpe
+    unless @constructor._snapshotType? then throw new Error Aggregate::ERRORS.undefinedSnapshotTpe
     data = {}
     data.id = @_id
     data.state = @_state

--- a/source/server/domain/aggregate.coffee
+++ b/source/server/domain/aggregate.coffee
@@ -20,6 +20,7 @@ class Space.eventSourcing.Aggregate extends Space.Object
     domainEventRequired: "#{Aggregate}: Event must inherit from Space.domain.Event"
     cannotHandleMessage: "#{Aggregate}: Cannot handle: "
     invalidEventSourceId: "#{Aggregate}: The given event has an invalid source id."
+    undefinedSnapshotTpe: "#{Aggregate}: Snapshot type is undefined. Did you forget to call: #{Aggregate}.registerSnapshotType()?"
   }
 
   @createFromHistory: (events) -> new this(events[0].sourceId, events)
@@ -36,7 +37,7 @@ class Space.eventSourcing.Aggregate extends Space.Object
     }
 
   constructor: (id, data, isSnapshot) ->
-    unless id? then throw new Error Aggregate::ERRORS.guidRequired
+#    unless id? then throw new Error Aggregate::ERRORS.guidRequired
     # This aggregate is created from a command -> assign targetId
     @_id = if (id instanceof Command) then id.targetId else id
     @_events = []
@@ -58,6 +59,7 @@ class Space.eventSourcing.Aggregate extends Space.Object
   getEvents: -> @_events
 
   getSnapshot: ->
+#    unless @constructor._snapshotType? then throw new Error Aggregate::ERRORS.undefinedSnapshotTpe
     data = {}
     data.id = @_id
     data.state = @_state


### PR DESCRIPTION
We have this error now instead of 'undefined is not a function' when snapshot is not registered:

`Error: Space.eventSourcing.Aggregate: Snapshot type is undefined. Did you forget to call: Space.eventSourcing.Aggregate.registerSnapshotType()?`
