### PR TITLE
Fix/concurrency error handling

### DIFF
--- a/source/server/infrastructure/commit_publisher.coffee
+++ b/source/server/infrastructure/commit_publisher.coffee
@@ -37,8 +37,8 @@ class Space.eventSourcing.CommitPublisher extends Space.Object
     @_publishHandle?.stop()
 
   publishCommit: (commit) =>
+    @_setProcessingTimeout(commit)
     try
-      @_setProcessingTimeout(commit)
       for event in commit.changes.events
         @log.debug @_logMsg("publishing #{event.typeName()}"), event
         @eventBus.publish event

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -54,7 +54,13 @@ class Space.eventSourcing.CommitStore extends Space.Object
 
       # insert commit with next version
       @log.debug(@_logMsg("Inserting commit"), commit)
-      commitId = @commits.insert commit
+      try
+        commitId = @commits.insert commit
+      catch error
+        throw new Error "While inserting:\n
+          #{JSON.stringify(commit)}\n
+          error:#{error.message}\n
+          stack:#{error.stack}"
 
       @commitPublisher.publishCommit
         _id: commitId,

--- a/tests/infrastructure/commit_publisher.unit.coffee
+++ b/tests/infrastructure/commit_publisher.unit.coffee
@@ -120,6 +120,7 @@ describe "Space.eventSourcing.CommitPublisher", ->
       update: $push: { receivers: { appId: @appId, receivedAt: new Date() } }
     })
     @commitPublisher._markAsProcessed = ->
+    @commitPublisher._setProcessingTimeout = ->
     @commitPublisher.publishCommit(@commitPublisher._parseCommit(lockedCommit))
     @commitPublisher._failCommitProcessingAttempt(@commitId)
 
@@ -145,6 +146,7 @@ describe "Space.eventSourcing.CommitPublisher", ->
 
   it "stores each commit's publishing timeout using the id as a the key", ->
     commit = Commits.findOne(@commitId)
+    @commitPublisher._failCommitProcessingAttempt = ->
     @commitPublisher._setProcessingTimeout(commit)
     expect(@commitPublisher._inProgress).to.have.property(@commitId);
     expect(@commitPublisher._inProgress[@commitId]).to.respondTo('_onTimeout');


### PR DESCRIPTION
 This squashes a major bug outlined in #75 when the system is under load relating to concurrency and race conditions.

Thanks again @qejk for your diligent debugging !