### PR TITLE
meta eventCorrelationProperty values are now converted to a string if a Guid

### DIFF
--- a/source/server/domain/process.coffee
+++ b/source/server/domain/process.coffee
@@ -27,7 +27,10 @@ class Space.eventSourcing.Process extends Space.eventSourcing.Aggregate
 
   trigger: (command) ->
     command.meta ?= {}
-    command.meta[this.eventCorrelationProperty] = this.getId()
+    if this.getId.toString?
+      command.meta[this.eventCorrelationProperty] = this.getId().toString()
+    else
+      command.meta[this.eventCorrelationProperty] = this.getId()
     @_commands.push command
 
   getCommands: -> @_commands

--- a/source/server/domain/process.coffee
+++ b/source/server/domain/process.coffee
@@ -27,10 +27,7 @@ class Space.eventSourcing.Process extends Space.eventSourcing.Aggregate
 
   trigger: (command) ->
     command.meta ?= {}
-    if this.getId.toString?
-      command.meta[this.eventCorrelationProperty] = this.getId().toString()
-    else
-      command.meta[this.eventCorrelationProperty] = this.getId()
+    command.meta[this.eventCorrelationProperty] = this.getId().toString()
     @_commands.push command
 
   getCommands: -> @_commands

--- a/tests/domain/process.unit.coffee
+++ b/tests/domain/process.unit.coffee
@@ -26,9 +26,9 @@ describe "Space.eventSourcing.Process", ->
       @process = new TestProcess @processId
       expect(@process.getCommands()).to.be.empty
 
-    it 'can be passed a object that returns the id string via a toString method', ->
+    it 'can be passed a Guid for the id', ->
       @process = new TestProcess @processId
-      expect(@process.getId.toString).to.exist
+      expect(@process.getId()).to.be.instanceOf(Guid)
 
     it 'can be passed a string for the id', ->
       @process = new TestProcess '123'


### PR DESCRIPTION
Implements #67 cc @darko-mijic 