### PR TITLE
Feature/commit publishing exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,23 @@ Concurrency exceptions can occur in a race condition where two messages are
    This should be safe from endless loops, because if the aggregate's state
    has since changed rendering the message now invalid, a domain exception 
    will be thrown, which is handled elsewhere being an application concern.
+- **New index** `{ "_id": 1, "receivers.appId": 1 }` on commits collection to optimise commit publishing.
+
+
+### Changes
+
 - **Logging** has been made more production-friendly, pushing some of the noisy `info`
 entries from the commit call down to `debug`. In effect, you could log `debug` to
 a local file and rotate as needed, and `info` to an external system that gives you
 the system-level updates rather than every action being taken.
-- **New index** `{ "_id": 1, "receivers.appId": 1 }` on commits collection to optimise commit publishing.
 - `eventCorrelationProperty` of processes are now converted to a string if a Guid.
- 
+
+#### Future breaking, now depreciated
+
+- `commitPublisher.publishCommit(commit)`
+now use `commitPublisher.publishChanges(changes, commitId)`
+
+
 ### Bug Fixes
 - Commit **processing timeout** had a bug that caused the publisher to fail commits that most
 likely had already been fully processed, due to the timeout reference being lost, so was not being . Failing a commit that has already been processed

--- a/source/server/infrastructure/commit_publisher.coffee
+++ b/source/server/infrastructure/commit_publisher.coffee
@@ -110,4 +110,7 @@ class Space.eventSourcing.CommitPublisher extends Space.Object
     "#{@configuration.appId}: #{this}: #{message}"
 
   # Backwards compatability
-  publishCommit: (commit) => @publishChanges(commit.changes, commit._id)
+  publishCommit: (commit) ->
+    @log.warning(@_logMsg('CommitPublisher publishCommit(commit) is
+      depreciated. Use publishChanges(changes, commitId)'))
+    @publishChanges(commit.changes, commit._id)

--- a/source/server/infrastructure/commit_publisher.coffee
+++ b/source/server/infrastructure/commit_publisher.coffee
@@ -80,7 +80,7 @@ class Space.eventSourcing.CommitPublisher extends Space.Object
     })
     if(failedCommit)
       @log.error(@_logMsg("#{commitId} TIMED OUT"), changes)
-      @_cleanupTimeout(commitId)
+    @_cleanupTimeout(commitId)
 
   _clearTimeout: (commitId) ->
     @meteor.clearTimeout(@_inProgress[commitId])

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -69,12 +69,7 @@ class Space.eventSourcing.CommitStore extends Space.Object
         else
           throw error
 
-      @commitPublisher.publishCommit
-        _id: commitId,
-        changes: {
-          events: changes.events
-          commands: changes.commands
-        }
+      @commitPublisher.publishChanges(changes, commitId)
 
   getEvents: (sourceId, versionOffset=1) ->
     events = []

--- a/source/server/infrastructure/router.coffee
+++ b/source/server/infrastructure/router.coffee
@@ -87,8 +87,8 @@ class Space.eventSourcing.Router extends Space.messaging.Controller
                        #{@eventSourceable}<#{aggregateId}>\n"), message)
     try
       eventSourceable = @repository.find @eventSourceable, aggregateId
-      @injector.injectInto(eventSourceable)
       throw Router.ERRORS.cannotHandleMessage(message) if !eventSourceable?
+      @injector.injectInto(eventSourceable)
       eventSourceable = @_handleDomainErrors(-> eventSourceable.handle message)
       @repository.save(eventSourceable) if eventSourceable?
     catch error

--- a/source/server/infrastructure/router.coffee
+++ b/source/server/infrastructure/router.coffee
@@ -112,11 +112,13 @@ class Space.eventSourcing.Router extends Space.messaging.Controller
 
   _handleSaveErrors: (error, message, aggregateId) ->
     if error instanceof Space.eventSourcing.CommitConcurrencyException
-      @log.warning(@_logMsg("Re-handling message due to concurrency exception with message #{message.typeName()} for
-                       #{@eventSourceable}<#{aggregateId}>\n"), message)
-      # Concurrency exceptions can often be resolved by simply re-handling the message.
-      # This should be safe from endless loops, because if the aggregate's state
-      # has since changed and the message is rejected, a domain exception is thrown
+      @log.warning(@_logMsg("Re-handling message due to concurrency exception
+      with message #{message.typeName()} for #{@eventSourceable}
+      <#{aggregateId}>"), message)
+      # Concurrency exceptions can often be resolved by simply re-handling the
+      # message. This should be safe from endless loops, because if the
+      # aggregate's state has since changed and the message is rejected,
+      # a domain exception will be thrown, which is an application concern.
       @messageHandler(message)
     else
       throw error

--- a/tests/infrastructure/commit_store.unit.coffee
+++ b/tests/infrastructure/commit_store.unit.coffee
@@ -31,7 +31,7 @@ describe "Space.eventSourcing.CommitStore", ->
     @appId = 'TestApp'
     @commitStore = new CommitStore {
       commits: new Mongo.Collection(null)
-      commitPublisher: publishCommit: sinon.spy()
+      commitPublisher: publishChanges: sinon.spy()
       configuration: { appId: @appId }
       log: Space.log
     }
@@ -69,11 +69,8 @@ describe "Space.eventSourcing.CommitStore", ->
       }
 
       expect(insertedCommits).toMatch [serializedCommit]
-      expect(@commitStore.commitPublisher.publishCommit)
-      .to.have.been.calledWithMatch changes: {
-        events: [testEvent]
-        commands: [testCommand]
-      }
+      expect(@commitStore.commitPublisher.publishChanges)
+      .to.have.been.calledWithMatch(changes, insertedCommits[0]._id)
 
     it 'throws a concurrency exception if the version in the store does not equal the expected version', ->
       sourceId = new Guid()

--- a/tests/infrastructure/repository.unit.coffee
+++ b/tests/infrastructure/repository.unit.coffee
@@ -46,7 +46,7 @@ describe "Space.eventSourcing.Repository", ->
     })
     @commitStore = new CommitStore {
       commits: new Mongo.Collection(null)
-      commitPublisher: { publishCommit: -> }
+      commitPublisher: { publishChanges: -> }
       configuration: { appId: @appId }
       log: Space.log
     }

--- a/tests/integration/event-sourceable-dependency-injection.js
+++ b/tests/integration/event-sourceable-dependency-injection.js
@@ -12,10 +12,8 @@ describe("Space.eventSourcing.Aggregate - dependency injection", function() {
       targetId: new Guid(),
       name: 'MyStrangeCustomerName'
     });
-
     this.app.start();
     this.app.commandBus.send(command);
-
     expect(Test.myAggregateDependency).to.have.been.calledOnce;
   });
 


### PR DESCRIPTION
First stage here is a cleanup of the API (backwards compatible where needed) in preparation. Opening early for feedback

The main motivation for `publishChanges` was to clarify that the object passed in should be not relied upon for reading the state of the commit, instead query for it!

Will be addressing #58 and #84

**Ok in summary** this PR is mainly a refactor, and better application of the timeout features to reduce database calls and also remove the potential race condition. Handling of exceptions bubbling up at this point is really is just a matter of marking the commit as failed, then throwing the error, as it's not practical to just retry without better understanding the error. It's easy enough to implement a custom re-publish strategy, but Space shouldn't bake this in (at this stage) IMO