### PR TITLE
Return early in makeSnapshotOf if versionFrequency not met

### DIFF
--- a/source/server/infrastructure/snapshotter.coffee
+++ b/source/server/infrastructure/snapshotter.coffee
@@ -31,6 +31,8 @@ class Space.eventSourcing.Snapshotter extends Space.Object
   makeSnapshotOf: (aggregate) ->
     id = aggregate.getId().toString()
     currentVersion = aggregate.getVersion()
+    # Return early before the first snapshot point is reached
+    if(currentVersion) < @versionFrequency then return
     data = @collection.findOne _id: id
     data?.snapshot = @ejson.parse(data.snapshot)
     snapshot = aggregate.getSnapshot()


### PR DESCRIPTION
This fixes a non-critical bug with the Snapshotter where every new aggregate instance would have a snapshot generated after the commit is added.This performance/design fix returns early from `makeSnapshotOf` before it hits the database, parses EJSON, etc and then also writing back to the snapshots collection, so this should be a significant boost particularly when batch importing. Outside of that, this is really what expected from a snapshotting feature.