### PR TITLE
Feature/projection rebuilder better logging, exception handling, and reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ Concurrency exceptions can occur in a race condition where two messages are
    This should be safe from endless loops, because if the aggregate's state
    has since changed rendering the message now invalid, a domain exception 
    will be thrown, which is handled elsewhere being an application concern.
-- **New index** `{ "_id": 1, "receivers.appId": 1 }` on commits collection to optimise commit publishing.
-
+- **New index** `{ "_id": 1, "receivers.appId": 1 }` on commits collection to
+  optimise commit publishing.
+- `projectionRebuilder.rebuild` now returns a response object containing a
+  messageand duration property
+-  `ProjectionRebuilder` now logs detailed debug information, and two info
+  updates to provide feedback at the desired level.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ Concurrency exceptions can occur in a race condition where two messages are
    will be thrown, which is handled elsewhere being an application concern.
 - **New index** `{ "_id": 1, "receivers.appId": 1 }` on commits collection to
   optimise commit publishing.
-- `projectionRebuilder.rebuild` now returns a response object containing a
-  messageand duration property
+- `projectionRebuilder.rebuild` now returns a response object containing an
+  error and result, which the former will be null if no non-fatal errors were
+  thrown. The result contains a message and duration property.
 -  `ProjectionRebuilder` now logs detailed debug information, and two info
   updates to provide feedback at the desired level.
 
@@ -26,6 +27,8 @@ entries from the commit call down to `debug`. In effect, you could log `debug` t
 a local file and rotate as needed, and `info` to an external system that gives you
 the system-level updates rather than every action being taken.
 - `eventCorrelationProperty` of processes are now converted to a string if a Guid.
+- `ProjectionRebuilder` gracefully handles errors, reapplying the backup and resetting
+  telling the projection to `exitRebuildMode` before re-throwing the error.
 
 #### Future breaking, now depreciated
 

--- a/source/server/errors.js
+++ b/source/server/errors.js
@@ -3,3 +3,15 @@ Space.Error.extend('Space.eventSourcing.CommitConcurrencyException', {
     Space.Error.call(this, `Expected entity ${aggregateId} to be at version in ${expectedVersion} but is at version ${currentVersion}`);
   }
 });
+
+Space.Error.extend('Space.eventSourcing.ProjectionAlreadyRebuilding', {
+  Constructor(name) {
+    Space.Error.call(this, `Projection ${name} is already being rebuilt`);
+  }
+});
+
+Space.Error.extend('Space.eventSourcing.ProjectionNotRebuilding', {
+  Constructor(name) {
+    Space.Error.call(this, `Expected projection ${name} to be in a state of rebuilding`);
+  }
+});

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -19,11 +19,22 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
     queue = []
     startHrTime = process.hrtime()
 
-    @log.info(@_logMsg("Rebuilding #{projections}"))
-
     # Loop over all projections that should be rebuilt
     for projectionId in projections
       projection = @injector.get projectionId
+
+      # Tell the projection that it will be rebuilt now
+      try
+        projection.enterRebuildMode()
+      catch error
+        if error instanceof Space.eventSourcing.ProjectionAlreadyRebuilding
+          @log.warning(@_logMsg(error.message))
+          return { error: error }
+        else
+          throw error
+
+      @log.info(@_logMsg("Rebuilding #{projection}"))
+
       # Save backups of the real collections to restore them later and
       # override the real collections with in-memory pendants
       for collectionId in @_getCollectionIdsOfProjection(projection)
@@ -32,9 +43,6 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
         @injector.override(collectionId).to new @mongo.Collection(null)
         @log.debug(@_logMsg("Injector mapping for #{collectionId} overridden with in-memory staging collection"))
 
-
-      # Tell the projection that it will be rebuilt now
-      projection.enterRebuildMode()
       queue.push projection
 
     try
@@ -43,7 +51,6 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
       for event in @commitStore.getAllEvents()
         projection.on(event, true) for projection in queue
       @log.debug(@_logMsg("Finished passing events to #{projectionId}"))
-
       # Update the real collection data with the in-memory versions
       for collectionId, realCollection of realCollectionsBackups
         inMemoryCollection = @injector.get(collectionId)
@@ -55,17 +62,22 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
           @log.debug(@_logMsg("Rebuilt staged collection batch inserted into #{collectionId}"))
         else
           @log.info(@_logMsg("No data to insert after replaying events for #{collectionId}"))
-        # Restore original collection and cleanup backup
         @injector.override(collectionId).to realCollection
-        delete realCollectionsBackups[collectionId]
       @log.debug(@_logMsg("Restored collection injector mappings for #{projectionId}"))
-    finally
-      for projection in queue
-        projection.exitRebuildMode()
+    catch error
+      for collectionId in @_getCollectionIdsOfProjection(projection)
+        @injector.override(collectionId).to realCollectionsBackups[collectionId]
+        @log.warning(@_logMsg("Rolled back to previous version of #{collectionId} due to error"))
+      console.log(error)
+      projection.exitRebuildMode()
+      throw error
+
+    for projection in queue
+      projection.exitRebuildMode()
     duration = Math.round(process.hrtime(startHrTime)[1]/1000000)
     response = { message: "Finished rebuilding #{projections} in #{duration}ms", duration: duration }
     @log.info(@_logMsg(response.message))
-    return response
+    return { error: null, response: response }
 
   _getCollectionIdsOfProjection: (projection) ->
     collectionIds = []

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -63,9 +63,9 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
       for projection in queue
         projection.exitRebuildMode()
     duration = Math.round(process.hrtime(startHrTime)[1]/1000000)
-    responseMessage = "Finished rebuilding #{projections} in #{duration}ms"
-    @log.info(@_logMsg(responseMessage))
-    return responseMessage
+    response = { message: "Finished rebuilding #{projections} in #{duration}ms", duration: duration }
+    @log.info(@_logMsg(response.message))
+    return response
 
   _getCollectionIdsOfProjection: (projection) ->
     collectionIds = []

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -46,11 +46,10 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
       queue.push projection
 
     try
-      # Loop through all events and hand them individually to all projections
-      @log.debug(@_logMsg("Starting to pass events to #{projectionId} from Commit Store"))
+      @log.debug(@_logMsg("Starting to pass all Commit Store events to the projections"))
       for event in @commitStore.getAllEvents()
         projection.on(event, true) for projection in queue
-      @log.debug(@_logMsg("Finished passing events to #{projectionId}"))
+      @log.debug(@_logMsg("Finished passing events"))
       # Update the real collection data with the in-memory versions
       for collectionId, realCollection of realCollectionsBackups
         inMemoryCollection = @injector.get(collectionId)

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -68,7 +68,6 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
       for collectionId in @_getCollectionIdsOfProjection(projection)
         @injector.override(collectionId).to realCollectionsBackups[collectionId]
         @log.warning(@_logMsg("Rolled back to previous version of #{collectionId} due to error"))
-      console.log(error)
       projection.exitRebuildMode()
       throw error
 

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -74,4 +74,5 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
     return collectionIds
 
   _logMsg: (message) ->
-    "#{@configuration.appId}: #{this}: #{message}"
+    prefix = "#{@configuration.appId}: " if @configuration?.appId
+    "#{prefix}#{this}: #{message}"

--- a/source/server/infrastructure/projection-rebuilder.coffee
+++ b/source/server/infrastructure/projection-rebuilder.coffee
@@ -55,15 +55,16 @@ class Space.eventSourcing.ProjectionRebuilder extends Space.Object
           @log.debug(@_logMsg("Rebuilt staged collection batch inserted into #{collectionId}"))
         else
           @log.info(@_logMsg("No data to insert after replaying events for #{collectionId}"))
-        # Restore original collections
+        # Restore original collection and cleanup backup
         @injector.override(collectionId).to realCollection
-        @log.debug(@_logMsg("Restored collection injector mappings for #{projectionId}"))
+        delete realCollectionsBackups[collectionId]
+      @log.debug(@_logMsg("Restored collection injector mappings for #{projectionId}"))
     finally
       for projection in queue
         projection.exitRebuildMode()
-      duration = Math.round(process.hrtime(startHrTime)[1]/1000000)
-      responseMessage = "Finished rebuilding #{projections} in #{duration}ms"
-      @log.info(@_logMsg(responseMessage))
+    duration = Math.round(process.hrtime(startHrTime)[1]/1000000)
+    responseMessage = "Finished rebuilding #{projections} in #{duration}ms"
+    @log.info(@_logMsg(responseMessage))
     return responseMessage
 
   _getCollectionIdsOfProjection: (projection) ->

--- a/source/server/infrastructure/projection.coffee
+++ b/source/server/infrastructure/projection.coffee
@@ -41,4 +41,5 @@ class Space.eventSourcing.Projection extends Space.Object
     true if expectedState is @_state
 
   _logMsg: (message) ->
-    "#{@configuration.appId}: #{this}: #{message}"
+    prefix = "#{@configuration.appId}: " if @configuration?.appId
+    "#{prefix}#{this}: #{message}"

--- a/source/server/infrastructure/projection.coffee
+++ b/source/server/infrastructure/projection.coffee
@@ -10,7 +10,10 @@ class Space.eventSourcing.Projection extends Space.Object
     super
     @_state = 'projecting'
     @_queuedEvents = []
-    @dependencies = {}
+    @dependencies = {
+      configuration: 'configuration'
+      log: 'log'
+    }
     _.extend @dependencies, @constructor::dependencies, @collections
 
   on: (event, isRebuildEvent=false) ->
@@ -24,12 +27,18 @@ class Space.eventSourcing.Projection extends Space.Object
     if @_is('rebuilding')
       throw new Error "Invalid state: Cannot enterRebuildMode as #{@constructor.toString()} is already rebuilding"
     @_state = 'rebuilding'
+    @log.debug(@_logMsg("State: #{@_state}"))
+
 
   exitRebuildMode: ->
     if !@_is('rebuilding')
       throw new Error "Invalid state: Cannot exitRebuildMode as #{@constructor.toString()} is not rebuilding"
     @_state = 'projecting'
     @on(event) for event in @_queuedEvents
+    @log.debug(@_logMsg("State: #{@_state}"))
 
   _is: (expectedState) ->
     true if expectedState is @_state
+
+  _logMsg: (message) ->
+    "#{@configuration.appId}: #{this}: #{message}"

--- a/source/server/infrastructure/projection.coffee
+++ b/source/server/infrastructure/projection.coffee
@@ -25,14 +25,14 @@ class Space.eventSourcing.Projection extends Space.Object
 
   enterRebuildMode: ->
     if @_is('rebuilding')
-      throw new Error "Invalid state: Cannot enterRebuildMode as #{@constructor.toString()} is already rebuilding"
+      throw new Space.eventSourcing.ProjectionAlreadyRebuilding(@constructor.toString())
     @_state = 'rebuilding'
     @log.debug(@_logMsg("State: #{@_state}"))
 
 
   exitRebuildMode: ->
     if !@_is('rebuilding')
-      throw new Error "Invalid state: Cannot exitRebuildMode as #{@constructor.toString()} is not rebuilding"
+      throw new Space.eventSourcing.ProjectionNotRebuilding(@constructor.toString())
     @_state = 'projecting'
     @on(event) for event in @_queuedEvents
     @log.debug(@_logMsg("State: #{@_state}"))

--- a/source/server/module.coffee
+++ b/source/server/module.coffee
@@ -63,6 +63,7 @@ class Space.eventSourcing extends Space.Module
       commitsName = Space.getenv('SPACE_ES_COMMITS_COLLECTION_NAME', 'space_eventSourcing_commits')
       CommitsCollection = new @mongo.Collection commitsName, @_mongoConnection()
       CommitsCollection._ensureIndex { "sourceId": 1, "version": 1 }, unique: true
+      CommitsCollection._ensureIndex { "receivers.appId": 1 }
       CommitsCollection._ensureIndex { "_id": 1, "receivers.appId": 1 }
       Space.eventSourcing.commitsCollection = CommitsCollection
     @injector.map('Space.eventSourcing.Commits').to CommitsCollection

--- a/tests/infrastructure/projection-rebuilder.tests.coffee
+++ b/tests/infrastructure/projection-rebuilder.tests.coffee
@@ -103,3 +103,29 @@ describe 'Space.eventSourcing.ProjectionRebuilder', ->
       _id: @event.sourceId
       value: @event.value
     ]
+
+  it 'rejects attempts to rebuild projections that are already being rebuilt', ->
+
+    rebuilder = @app.injector.get 'Space.eventSourcing.ProjectionRebuilder'
+    projection = @app.injector.get 'FirstProjection'
+    projection.enterRebuildMode()
+    try
+      rebuilder.rebuild ['FirstProjection']
+    catch error
+      expect(error).to.be.instanceOf(Space.eventSourcing.ProjectionAlreadyRebuilding)
+
+  it 'restores the real collection and returns the projection to the correct
+    state if an exception occurs in the event replay', ->
+
+    rebuilder = @app.injector.get 'Space.eventSourcing.ProjectionRebuilder'
+    projection = @app.injector.get 'FirstProjection'
+    collection = @app.injector.get 'FirstCollection'
+    projection.on = -> throw new Error('Simulated error in replay')
+
+    try
+      rebuilder.rebuild ['FirstProjection']
+    catch error
+      expect(error).to.deep.equal(new Error 'Simulated error in replay')
+    # Only persistent collections have a connection
+    expect(collection._connection).to.not.equal(null);
+    expect(projection._state).to.equal('projecting')

--- a/tests/infrastructure/projection.unit.coffee
+++ b/tests/infrastructure/projection.unit.coffee
@@ -12,6 +12,12 @@ describe 'Space.eventSourcing.Projection', ->
       eventBus: new Space.messaging.EventBus()
       meteor: Meteor
       underscore: _
+      log: {
+        debug: ->
+        warning: ->
+        info: ->
+        error: ->
+      }
     })
     @projection.onDependenciesReady()
     @projection.subscribe TestEvent, @handler


### PR DESCRIPTION
This solidifies the current feature with additional logging, tests, and error handling. It includes a rollback to the backup on error, and graceful handling to reset the state of the projection so it doesn't get stuck in a state of 'rebuilding'. The response is now useful, containing an error if non-fatal, and the high resolution duration rounded to ms in both a human-friendly message and raw value. 

See the CHANGELOG for detail.