### PR TITLE
Fix/only process external commits containing messages that can be handled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,12 @@ Concurrency exceptions can occur in a race condition where two messages are
 - Commits made in other apps will now only be processed if they contain
    messages with registered handlers in the current app. Prior to every
    commit would be returned by the observer, and then it was decided to
-   publish/send, or ignore. The **one caveat** is that in the future if
-   an app subscribes to a legacy message, it will process all from the past,
-   which may or may not be desired. We may look at introducing rules around
-   processing legacy commits if a natural control surfaces.
+   publish/send, or ignore. This changes the outcome of adding handlers 
+   in to existing messages, as it will process all from the start of the store,
+   which may or may not be desired. It's up to the application to control this
+   but is now more flexible and the system can be brought up to a consistent
+   state as if the handlers were in place the whole time. **Consider this
+   carefully!**
 
 - **Logging** has been made more production-friendly, pushing some of the noisy `info`
 entries from the commit call down to `debug`. In effect, you could log `debug` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ Concurrency exceptions can occur in a race condition where two messages are
   updates to provide feedback at the desired level.
 
 ### Changes
+- Commits made in other apps will now only be processed if they contain
+   messages with registered handlers in the current app. Prior to every
+   commit would be returned by the observer, and then it was decided to
+   publish/send, or ignore. The **one caveat** is that in the future if
+   an app subscribes to a legacy message, it will process all from the past,
+   which may or may not be desired. We may look at introducing rules around
+   processing legacy commits if a natural control surfaces.
 
 - **Logging** has been made more production-friendly, pushing some of the noisy `info`
 entries from the commit call down to `debug`. In effect, you could log `debug` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,14 +44,19 @@ now use `commitPublisher.publishChanges(changes, commitId)`
 
 
 ### Bug Fixes
-- Commit **processing timeout** had a bug that caused the publisher to fail commits that most
-likely had already been fully processed, due to the timeout reference being lost, so was not being . Failing a commit that has already been processed
-had to effect, but it was causing the commit records to be left in an invalid state. This
-fix also places a guard to protect against race conditions in the event of a genuine timeout,
-or redelivery via the infrastructure.
+- Commit **processing timeout** had a bug that caused the publisher to fail
+ commits that most likely had already been fully processed, due to the timeout
+ reference being lost, so was not being . Failing a commit that has already
+  been processed had to effect, but it was causing the commit records to be
+  left in an invalid state. This fix also places a guard to protect against
+  race conditions in the event of a genuine timeout, or redelivery via the
+  infrastructure.
 - Now the repository only calls `aggregate.replayHistory` if there have been 
-events since the last snapshot.
-- Fixes a non-critical bug with the Snapshotter where every new aggregate instance would have the snapshot generated after the commit is added rather than waiting for the version specified in configuration. This is a performance improvement, particularly for batch importing.
+  events since the last snapshot.
+- Fixes a non-critical bug with the Snapshotter where every new aggregate
+  instance would have the snapshot generated after the commit is added rather
+  than waiting for the version specified in configuration. This is a
+  performance improvement, particularly for batch importing.
 
 ## 3.0.1
 ### Changes to projection rebuilder

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,1 +1,6 @@
-{}
+{
+  "space:messaging": {
+    "git":"https://github.com/meteor-space/messaging.git",
+    "version": "9e61dd2a79cae9068e900d650a68f0d8a4e1f29a"
+  }
+}

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,1 +1,6 @@
-{}
+{
+  "space:messaging": {
+    "git":"https://github.com/meteor-space/messaging.git",
+    "version": "c91630a60ed25f5e89b9c309075b91d9fc5c55a9"
+  }
+}

--- a/git-packages.json
+++ b/git-packages.json
@@ -1,6 +1,1 @@
-{
-  "space:messaging": {
-    "git":"https://github.com/meteor-space/messaging.git",
-    "version": "c91630a60ed25f5e89b9c309075b91d9fc5c55a9"
-  }
-}
+{}

--- a/source/server/infrastructure/commit_publisher.coffee
+++ b/source/server/infrastructure/commit_publisher.coffee
@@ -99,7 +99,7 @@ class Space.eventSourcing.CommitPublisher extends Space.Object
     commands = []
     # Only parse events that can be handled by this app
     for event in commit.changes.events
-      if @_supportsEjsonType event.type
+      if @_supportsEjsonType(event.type) and @eventBus.hasHandlerFor(event.type)
         EventType = Space.resolvePath(event.type)
         events.push EventType.fromData(event.data)
     # Only parse commands that can be handled by this app

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -73,7 +73,6 @@ class Space.eventSourcing.CommitStore extends Space.Object
     @commitPublisher.publishChanges(changes, commitId)
 
   getEvents: (sourceId, versionOffset=1) ->
-    events = []
     withVersionOffset = {
       sourceId: sourceId.toString()
       version: $gte: versionOffset

--- a/source/server/infrastructure/commit_store.coffee
+++ b/source/server/infrastructure/commit_store.coffee
@@ -47,7 +47,8 @@ class Space.eventSourcing.CommitStore extends Space.Object
       version: newVersion
       changes: serializedChanges
       insertedAt: new Date()
-      eventTypes: @_getEventTypes(changes.events)
+      eventTypes: @_getMessageTypes(changes.events)
+      commandTypes: @_getMessageTypes(changes.commands)
       sentBy: @configuration.appId
       receivers: [{ appId: @configuration.appId, receivedAt: new Date }]
     }
@@ -68,7 +69,7 @@ class Space.eventSourcing.CommitStore extends Space.Object
         )
       else
         throw error
-        
+
     @commitPublisher.publishChanges(changes, commitId)
 
   getEvents: (sourceId, versionOffset=1) ->
@@ -96,7 +97,7 @@ class Space.eventSourcing.CommitStore extends Space.Object
 
   _setEventVersion: (event, version) -> event.version = version
 
-  _getEventTypes: (events) -> events.map (event) -> event.typeName()
+  _getMessageTypes: (messages) -> messages.map (message) -> message.typeName()
 
   _getLastCommit: (sourceId) ->
     @commits.findOne(

--- a/tests/infrastructure/commit_publisher.unit.coffee
+++ b/tests/infrastructure/commit_publisher.unit.coffee
@@ -89,6 +89,7 @@ describe "Space.eventSourcing.CommitPublisher", ->
       sentBy: 'someOtherApp'
       receivers: [@externalReceiveEntry]
       eventTypes: [testEvent.typeName()]
+      commandTypes: [testCommand.typeName()]
     }
 
     @commitId = Commits.insert @commitProps
@@ -99,7 +100,8 @@ describe "Space.eventSourcing.CommitPublisher", ->
     @commitPublisher.stopPublishing()
     Commits.remove {}
 
-  it 'publishes externally added commits once in the current app, even with multiple app instances running', ->
+  it 'publishes externally added commits in the current app, even with
+    multiple app instances running', ->
     @commitPublisher.publishChanges = sinon.spy()
     @commitPublisher.startPublishing()
     insertedCommit = Commits.findOne(@commitId)
@@ -126,7 +128,8 @@ describe "Space.eventSourcing.CommitPublisher", ->
         test.exception err
     Meteor.setTimeout(waitFor(timeout), 20);
 
-  it 'handles errors by setting a failedAt field in the receivers array, and clearing the timeout', ->
+  it 'handles errors by setting a failedAt field in the receivers array,
+    and clearing the timeout', ->
     lockedCommit = Commits.findAndModify({
       query: $and: [_id: @commitId, { 'receivers.appId': { $nin: [@appId] }}]
       update: $push: { receivers: { appId: @appId, receivedAt: new Date() } }
@@ -142,7 +145,8 @@ describe "Space.eventSourcing.CommitPublisher", ->
     failedAt = _.findWhere(commit.receivers, {appId: @appId}).failedAt
     expect(failedAt).to.be.instanceOf(Date)
 
-  it 'avoids potential race condition between the timeout and processing being marked as completed', ->
+  it 'avoids potential race condition between the timeout and processing being
+    marked as completed', ->
     @configuration.eventSourcing.commitProcessing.timeout = 1
     commit = Commits.findAndModify({
       query: { $and: [

--- a/tests/infrastructure/commit_publisher.unit.coffee
+++ b/tests/infrastructure/commit_publisher.unit.coffee
@@ -25,6 +25,9 @@ class CPTotalChangedEvent extends Event
   @type 'tests.CommitPublisher.TotalChangedEvent'
   @fields: total: Number
 
+class CPUnSubscribedEvent extends Event
+  @type 'tests.CommitPublisher.UnSubscribedEvent'
+
 # =========== SPECS ============= #
 
 describe "Space.eventSourcing.CommitPublisher", ->
@@ -52,8 +55,8 @@ describe "Space.eventSourcing.CommitPublisher", ->
       ejson: EJSON
       log: Space.log
     }
-#    Un-comment this to log test cases
-#    @commitPublisher.log.start()
+    #  Un-comment this to log test cases
+    #  @commitPublisher.log.start()
     @commitStore = new CommitStore {
       commits: Commits
       commitPublisher: @commitPublisher
@@ -64,6 +67,11 @@ describe "Space.eventSourcing.CommitPublisher", ->
     @commitPublisher.commandBus.registerHandler(
       'Space.eventSourcing.CommitPublisher.TestCommand',
       @commandHandler
+    )
+    @eventSubscriber= sinon.spy()
+    @commitPublisher.eventBus.subscribeTo(
+      'Space.eventSourcing.CommitPublisher.TestEvent',
+      @eventSubscriber
     )
 
     @externalReceiveEntry = { appId: 'someOtherApp', receivedAt: new Date() }
@@ -100,8 +108,8 @@ describe "Space.eventSourcing.CommitPublisher", ->
     @commitPublisher.stopPublishing()
     Commits.remove {}
 
-  it 'publishes externally added commits in the current app, even with
-    multiple app instances running', ->
+  it 'publishes externally added commits in the current app if there is a
+    registered handler, even with multiple app instances running', ->
     @commitPublisher.publishChanges = sinon.spy()
     @commitPublisher.startPublishing()
     insertedCommit = Commits.findOne(@commitId)
@@ -112,6 +120,25 @@ describe "Space.eventSourcing.CommitPublisher", ->
       appId: @appId
       receivedAt: new Date()
     }])
+
+  it 'does not publish externally added commits without a registered handler in
+    the current app', ->
+    ignoreEvent = new CPUnSubscribedEvent({sourceId: '456'})
+    Commits.remove({})
+    commitToIgnoreProps = {
+      sourceId: '456'
+      version: 1
+      changes: {
+        events: [{
+          type: ignoreEvent.typeName(),
+          data: ignoreEvent.toData()
+        }]
+      }
+    }
+    Commits.insert(commitToIgnoreProps)
+    @commitPublisher.publishChanges = sinon.spy()
+    @commitPublisher.startPublishing()
+    expect(@commitPublisher.publishChanges).to.not.have.been.called
 
   it 'fails the processing attempt if timeout is reached', (test, waitFor) ->
     lockedCommit = Commits.findAndModify({

--- a/tests/infrastructure/commit_store.unit.coffee
+++ b/tests/infrastructure/commit_store.unit.coffee
@@ -66,6 +66,7 @@ describe "Space.eventSourcing.CommitStore", ->
         sentBy: @appId
         receivers: [{ appId: @appId, receivedAt: new Date() }]
         eventTypes: [TestEvent.toString()]
+        commandTypes: [TestCommand.toString()]
       }
 
       expect(insertedCommits).toMatch [serializedCommit]

--- a/tests/infrastructure/projection-rebuilder.tests.coffee
+++ b/tests/infrastructure/projection-rebuilder.tests.coffee
@@ -78,6 +78,7 @@ describe 'Space.eventSourcing.ProjectionRebuilder', ->
       }
       insertedAt: new Date()
       eventTypes: [TestEvent]
+      commandTypes: []
       sentBy: @app.configuration.appId
       receivers: [ appId: @app.configuration.appId, receivedAt: new Date()]
     }

--- a/tests/infrastructure/repository.unit.coffee
+++ b/tests/infrastructure/repository.unit.coffee
@@ -80,6 +80,7 @@ describe "Space.eventSourcing.Repository", ->
         sentBy: @appId
         receivers: [{ appId: @appId, receivedAt: new Date() }]
         eventTypes: [@myCreatedEvent.toString()]
+        commandTypes: []
       }
 
       expect(insertedCommits).toMatch [expectedCommit]
@@ -105,6 +106,7 @@ describe "Space.eventSourcing.Repository", ->
         sentBy: @appId
         receivers: [{ appId: @appId, receivedAt: new Date() }]
         eventTypes: [@myCreatedEvent.toString()]
+        commandTypes: [@myTriggeredCommand.toString()]
       }
 
       expect(insertedCommits).toMatch [expectedCommit]


### PR DESCRIPTION
From the CHANGELOG:

> Commits made in other apps will now only be processed if they contain messages with registered handlers in the current app. Prior to every commit would be returned by the observer, and then it was decided to publish/send, or ignore. The one caveat is that in the future if an app subscribes to a legacy message, it will process all from the past, which may or may not be desired. We may look at introducing rules around processing legacy commits if a natural control surfaces.

So the only issue is that last point. I've not put too much effort into thinking about how we can control this, but it was not acceptable to have _every_ commit processed by all apps, particularly with batch importing of large data sets that spawn new aggregates.

Let's discuss, as it's not a trivial issue, and we may need to have a strategy before merging this. WIP label has been applied for this reason

cc @darko-mijic, @qejk